### PR TITLE
docs: point footer changelog link to the in-docs changelog page

### DIFF
--- a/docs/website/docusaurus.config.js
+++ b/docs/website/docusaurus.config.js
@@ -158,7 +158,7 @@ const config = {
               },
               {
                 label: 'Changelog',
-                href: 'https://github.com/Arubacloud/arubacloud-resource-operator/releases',
+                to: '/changelog',
               },
             ],
           },


### PR DESCRIPTION
﻿## Summary

- Updates the footer Changelog link from the GitHub releases page (`href`) to the internal `/changelog` docs page (`to`)
- The changelog doc (`docs/website/docs/changelog.md`) and its sidebar entry already existed; this completes the wiring

## Test plan

- [ ] Run `npm run build` inside `docs/website` and verify no broken links
- [ ] Verify the footer "Changelog" link routes to `/changelog` (the in-docs page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
